### PR TITLE
fixed wrong SQL generation

### DIFF
--- a/secured_fields/lookups.py
+++ b/secured_fields/lookups.py
@@ -35,6 +35,7 @@ class EncryptedIn(lookups.In):
 
         # reformat to multiple OR condition instead
         sql += (' OR ' + sql) * (len(params) - 1)
+        sql = f'({sql})'
 
         # search using hash for each item
         params = [


### PR DESCRIPTION
Queries like MyModel.objects.filter(field1=value1, field2__in=[value2, value3, value4]) generate SQL like:
_SELECT myapp_mymodel.id, myapp_mymodel.field1, myapp_mymodel.field2 FROM myapp_mymodel
WHERE (
	myapp_mymodel.field1 LIKE '%$753c1e125cdad720a2fba683779cfa7fad9634b9cd18c469dcae0c08aaf38bfb' 
	AND myapp_mymodel.field2 LIKE '%$ad8edd221ec8e6d2c5375c5d17451d6d8c333cf4f71f8d156d01fa1cf0bf3dcb' 
	OR myapp_mymodel.field2 LIKE '%$64f2c70b44eaf33ffc9f66b0768fd6c44a3ce4981e84073434fac8aa6ed8899c' 
	OR myapp_mymodel.field2 LIKE '%$45cfcf36592e858b13d671ed333fe8a3bb966b80ff8cfc8f9003f2755375a0e9' 
)_ 
which isn't correct since AND has higher priority than OR.
This fix in fact adds missing brackets.